### PR TITLE
Make error message enumerable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alextheman/utility",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@alextheman/utility",
-      "version": "1.13.0",
+      "version": "1.13.1",
       "license": "ISC",
       "dependencies": {
         "zod": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alextheman/utility",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "main": "dist/index.cjs",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/types/APIError.ts
+++ b/src/types/APIError.ts
@@ -21,6 +21,7 @@ class APIError extends Error {
     } else {
       this.message = httpErrorCodeLookup[this.status as HTTPErrorCodes] ?? "API_ERROR";
     }
+    Object.defineProperty(this, "message", { enumerable: true });
     Object.setPrototypeOf(this, new.target.prototype);
   }
 }


### PR DESCRIPTION
Without this, if we just send the error object back directly through Express, the message property gets left out since it's inherited from Error. This ensures that we can actually send the object back with both the status and the message without needing to manually define it.