### PR TITLE
Add tsc --noEmit to lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "vitest run",
     "test-watch": "vitest",
     "format": "prettier --write --parser typescript 'src/**/*.ts' 'tests/**/*.test.ts' && ESLINT_MODE=fix eslint --fix 'src/**/*.ts' 'tests/**/*.ts'",
-    "lint": "ESLINT_MODE=lint eslint 'src/**/*.ts' 'tests/**/*.ts' && prettier --check --parser typescript 'src/**/*.ts' 'tests/**/*.ts'",
+    "lint": "tsc --noEmit && ESLINT_MODE=lint eslint 'src/**/*.ts' 'tests/**/*.ts' && prettier --check --parser typescript 'src/**/*.ts' 'tests/**/*.ts'",
     "prepare": "husky",
     "build": "tsup",
     "update-dependencies": "npx npm-check-updates -u && npm install",


### PR DESCRIPTION
This will catch errors given by TypeScript itself and will fail on type errors, unresolved named imports etc.