### PR TITLE
Add --suppress-all to format script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "zod": "^4.1.2"
       },
       "devDependencies": {
-        "@alextheman/eslint-plugin": "^1.7.0",
+        "@alextheman/eslint-plugin": "^1.8.1",
         "@eslint/js": "^9.34.0",
         "@types/node": "^24.3.0",
         "eslint": "^9.34.0",
@@ -30,9 +30,9 @@
       }
     },
     "node_modules/@alextheman/eslint-plugin": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@alextheman/eslint-plugin/-/eslint-plugin-1.7.0.tgz",
-      "integrity": "sha512-iDaewk8VeQAuWjjjE1A6ToR6WHH6fSdYzTqASUyKUVKGXlVAUwLo23ovzCD4+WOq5hWRMl/hWn6Goyu2eJJ8Aw==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@alextheman/eslint-plugin/-/eslint-plugin-1.8.1.tgz",
+      "integrity": "sha512-zitfgDrpVRVsU33KYQZFumLyMyXdU491M1fwdbwGTzrJ5RH4e/JKe54zbWOpb9h6/yResqWzIwgJ77thwPYLWg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
   "scripts": {
     "test": "vitest run",
     "test-watch": "vitest",
-    "format": "prettier --write --parser typescript 'src/**/*.ts' 'tests/**/*.test.ts' && ESLINT_MODE=fix eslint --fix --quiet 'src/**/*.ts' 'tests/**/*.ts'",
-    "lint": "tsc --noEmit && ESLINT_MODE=lint eslint 'src/**/*.ts' 'tests/**/*.ts' && prettier --check --parser typescript 'src/**/*.ts' 'tests/**/*.ts'",
+    "format": "prettier --write --parser typescript 'src/**/*.ts' 'tests/**/*.test.ts' && eslint --fix --suppress-all 'src/**/*.ts' 'tests/**/*.ts' && rm -f eslint-suppressions.json",
+    "lint": "tsc --noEmit && eslint 'src/**/*.ts' 'tests/**/*.ts' && prettier --check --parser typescript 'src/**/*.ts' 'tests/**/*.ts'",
     "prepare": "husky",
     "build": "tsup",
-    "update-dependencies": "npx npm-check-updates -u \"$@\" && npm install",
+    "update-dependencies": "bash -c 'npx npm-check-updates -u \"$@\" && npm install' --",
     "change-major": "npm version major -m \"Change version number to v%s\"",
     "change-minor": "npm version minor -m \"Change version number to v%s\"",
     "change-patch": "npm version patch -m \"Change version number to v%s\""
@@ -25,7 +25,7 @@
   "license": "ISC",
   "description": "",
   "devDependencies": {
-    "@alextheman/eslint-plugin": "^1.7.0",
+    "@alextheman/eslint-plugin": "^1.8.1",
     "@eslint/js": "^9.34.0",
     "@types/node": "^24.3.0",
     "eslint": "^9.34.0",


### PR DESCRIPTION
This ensures that any ESLint errors that come up when formatting are suppressed so that rules that would be caught by running the lint script don't block formatting.

Note that a side effect of this is that it generates an eslint-suppressions.json file by default, which helps people on legacy codebases to store existing violations without them blocking in the moment. In our case, however, we don't need this - we just want errors to be suppressed while fixing, while we rely on linting to catch errors instead.