### PR TITLE
Update ESLint plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "zod": "^4.1.12"
       },
       "devDependencies": {
-        "@alextheman/eslint-plugin": "^2.0.0",
+        "@alextheman/eslint-plugin": "^2.2.0",
         "@eslint/js": "^9.38.0",
         "@types/node": "^24.8.1",
         "eslint": "^9.38.0",
@@ -30,9 +30,9 @@
       }
     },
     "node_modules/@alextheman/eslint-plugin": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@alextheman/eslint-plugin/-/eslint-plugin-2.0.0.tgz",
-      "integrity": "sha512-sxCeXNj3Pp96NL/CABxfY43PpyJsexd1FpXW4YqPMF95Bu9jmYsGmPx3X1yMK9G+EWH5iia0YhuF47SCeS24lg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@alextheman/eslint-plugin/-/eslint-plugin-2.2.0.tgz",
+      "integrity": "sha512-3+NXu58aCp0r/LjQfgvGkJNdvdlRqMRBjC5IX5CYEaGNc2joVGGK2V/Q3dM8FZX/PrmawKMGp9bp/M8Y4YiGNQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "zod": "^4.1.12"
   },
   "devDependencies": {
-    "@alextheman/eslint-plugin": "^2.0.0",
+    "@alextheman/eslint-plugin": "^2.2.0",
     "@eslint/js": "^9.38.0",
     "@types/node": "^24.8.1",
     "eslint": "^9.38.0",


### PR DESCRIPTION
I recently updated ESLint plugin to ensure that all import paths are normalised. That is, they must look like they came from path.posix.normalize(). This ensures that import paths look clean and consistent.