### PR TITLE
Add tests for the utility types

### DIFF
--- a/tests/types/DisallowUndefined.test.ts
+++ b/tests/types/DisallowUndefined.test.ts
@@ -1,0 +1,14 @@
+import type { DisallowUndefined } from "src/types";
+
+import { describe, expectTypeOf, test } from "vitest";
+
+describe("NonUndefined", () => {
+  test("Resolves to the given type if undefined is not included", () => {
+    expectTypeOf<DisallowUndefined<string>>().toEqualTypeOf<string>();
+  });
+  test("Resolves to an error message if undefined is included", () => {
+    expectTypeOf<DisallowUndefined<string | undefined>>().toEqualTypeOf<
+      ["Error: Generic type cannot include undefined"]
+    >();
+  });
+});

--- a/tests/types/NonUndefined.test.ts
+++ b/tests/types/NonUndefined.test.ts
@@ -1,0 +1,12 @@
+import type { NonUndefined } from "src/types";
+
+import { describe, expectTypeOf, test } from "vitest";
+
+describe("NonUndefined", () => {
+  test("Resolves to the given type if undefined is not included", () => {
+    expectTypeOf<NonUndefined<string>>().toEqualTypeOf<string>();
+  });
+  test("Does not allow a type to include undefined", () => {
+    expectTypeOf<NonUndefined<string | undefined>>().not.toEqualTypeOf<string | undefined>();
+  });
+});

--- a/tests/types/OptionalOnCondition.test.ts
+++ b/tests/types/OptionalOnCondition.test.ts
@@ -1,0 +1,12 @@
+import type { OptionalOnCondition } from "src/types";
+
+import { describe, expectTypeOf, test } from "vitest";
+
+describe("OptionalOnCondition", () => {
+  test("Resolves to the type of the second type argument if first type argument is true", () => {
+    expectTypeOf<OptionalOnCondition<true, string>>().toEqualTypeOf<string>();
+  });
+  test("Resolves to a union of the second type and undefined if first type argument is false", () => {
+    expectTypeOf<OptionalOnCondition<false, string>>().toEqualTypeOf<string | undefined>();
+  });
+});


### PR DESCRIPTION
Yes, we can test compile-time type logic. It's so cursed, but also so amazing at the same time. It takes some getting used to because type information only exists at compile-time, so the tests will always pass if you run npm test - it's just that the TypeScript compiler does the type assertions and will error if the types aren't what it expects them to be.

Since these tests were included retroactively, it's not the most ideal workflow in this case. Usually when writing tests, we want to watch them fail first, then make them pass. This feels especially important for type tests because they always pass in runtime, which increases the chance of false positives. However, I have tried to make them fail first when writing the tests to ensure that it works as intended.