### PR TITLE
Add a mutation check to getRecordKeys

### DIFF
--- a/tests/functions/getRecordKeys.test.ts
+++ b/tests/functions/getRecordKeys.test.ts
@@ -18,4 +18,9 @@ describe("getRecordKeys", () => {
     // @ts-expect-error: This will give a compile-time error because it's not a record.
     getRecordKeys("hello");
   });
+  test("Does not mutate the input object", () => {
+    const input = Object.freeze({ firstKey: "First property", secondKey: "Second property" });
+    getRecordKeys(input);
+    expect(input).toEqual({ firstKey: "First property", secondKey: "Second property" });
+  });
 });


### PR DESCRIPTION
We're not actually mutating the input object, but it's always worth adding these mutation tests to be extra safe that we didn't mutate the input by accident.