### PR TITLE
Do not use NPM token anymore and instead use trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,4 +11,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: AlexMan123456/github-actions/npm-ci@9c4fdcd24fe08087706d73c424d579ef8719ae06 # v1.4.12
+      - uses: AlexMan123456/github-actions/npm-ci@73544f6e9a88630a2a0aa0036d35f8043491d05e # v2.0.2

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,6 +10,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: AlexMan123456/github-actions/npm-publish@9c4fdcd24fe08087706d73c424d579ef8719ae06 # v1.4.12
-        with:
-          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+      - uses: AlexMan123456/github-actions/npm-publish@73544f6e9a88630a2a0aa0036d35f8043491d05e # v2.0.2
+

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -20,6 +20,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-    - uses: AlexMan123456/github-actions/update-dependencies@9c4fdcd24fe08087706d73c424d579ef8719ae06 # v1.4.12
+    - uses: AlexMan123456/github-actions/update-dependencies@73544f6e9a88630a2a0aa0036d35f8043491d05e # v2.0.2
       with:
         PAT_GITHUB: ${{ secrets.PAT_GITHUB }}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "@alextheman/utility",
   "version": "2.14.0",
   "description": "Helpful utility functions",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AlexMan123456/utility.git"
+  },
   "license": "ISC",
   "author": "alextheman",
   "type": "module",


### PR DESCRIPTION
We can configure NPM such that we do not need to provide an NPM token anymore, and each package can be directly linked to the repository's publish script. This is far more secure and also prepares us for when classic NPM tokens stop working entirely.