### PR TITLE
Get rid of npm-check-updates reliance

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -40,7 +40,7 @@ jobs:
       run: pnpm install
 
     - name: Update JavaScript dependencies
-      run: pnpm run update-dependencies || true
+      run: pnpm update
 
     - name: Update GitHub Actions
       run: pnpx actions-up -y

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "prepare": "husky",
     "test": "vitest run",
     "test-watch": "vitest",
-    "update-dependencies": "bash -c 'pnpx npm-check-updates -u \"$@\" && pnpm install --no-frozen-lockfile' --",
     "use-live-eslint-plugin": "pnpm uninstall @alextheman/eslint-plugin && pnpm install --save-dev @alextheman/eslint-plugin",
     "use-local-eslint-plugin": "npm --prefix ../eslint-plugin run create-local-package && pnpm uninstall @alextheman/eslint-plugin && pnpm install --save-dev ../eslint-plugin/alextheman-eslint-plugin-*.tgz"
   },


### PR DESCRIPTION
pnpm update is actually a lot more nicer than npm update. npm update never really worked as it should've as it didn't change the package.json file with the updated versions, so I had to rely on npm-check-updates to have the package.json versions changed. pnpm update, on the other hand, actually changes the version numbers in package.json as well as the lockfile, which is the behaviour we want. As such, we no longer need another dependency to control dependency updates (which feels silly to me) and we can now just rely natively on the package manager to do it for us. That is a massive win right here.