### PR TITLE
Remove unnecessary --frozen-lockfile flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           run_install: false
         
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
 
       - name: Build package
         run: pnpm run build --if-present

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -30,7 +30,7 @@ jobs:
         run: npm install -g npm@latest
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
       
       - name: Build package
         run: pnpm run build


### PR DESCRIPTION
--frozen-lockfile is the default in GitHub Actions environments, so no need to specify it multiple times.