### PR TITLE
Rename refresh scripts to prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,13 +33,13 @@
     "lint-prettier-typescript": "prettier --check --parser typescript \"./**/*.ts\"",
     "lint-tsc": "tsc --noEmit",
     "prepare": "husky",
-    "refresh-live-eslint-plugin": "pnpm uninstall @alextheman/eslint-plugin && pnpm install --save-dev @alextheman/eslint-plugin",
-    "refresh-local-eslint-plugin": "dotenv -e .env -- sh -c 'ESLINT_PLUGIN_PATH=${LOCAL_ESLINT_PLUGIN_PATH:-../eslint-plugin}; pnpm --prefix \"$ESLINT_PLUGIN_PATH\" run build && pnpm uninstall @alextheman/eslint-plugin && pnpm install --save-dev -w file:\"$ESLINT_PLUGIN_PATH\"'",
+    "prepare-live-eslint-plugin": "pnpm uninstall @alextheman/eslint-plugin && pnpm install --save-dev @alextheman/eslint-plugin",
+    "prepare-local-eslint-plugin": "dotenv -e .env -- sh -c 'ESLINT_PLUGIN_PATH=${LOCAL_ESLINT_PLUGIN_PATH:-../eslint-plugin}; pnpm --prefix \"$ESLINT_PLUGIN_PATH\" run build && pnpm uninstall @alextheman/eslint-plugin && pnpm install --save-dev -w file:\"$ESLINT_PLUGIN_PATH\"'",
     "test": "vitest run",
     "test-watch": "vitest",
     "update-dependencies": "pnpm update --latest && pnpm update",
-    "use-live-eslint-plugin": "pnpm run refresh-live-eslint-plugin && pnpm run lint",
-    "use-local-eslint-plugin": "pnpm run refresh-local-eslint-plugin && pnpm run lint"
+    "use-live-eslint-plugin": "pnpm run prepare-live-eslint-plugin && pnpm run lint",
+    "use-local-eslint-plugin": "pnpm run prepare-local-eslint-plugin && pnpm run lint"
   },
   "dependencies": {
     "zod": "^4.1.13"


### PR DESCRIPTION
This feels clearer as the main concern of those scripts is to prepare the package. Refreshing is a secondary concern.