### PR TITLE
Get rid of needds: check-version

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -14,7 +14,6 @@ jobs:
 
   publish:
     if: ${{ github.repository == 'AlexMan123456/utility' }}
-    needs: check-version
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
I think this is why publish keeps failing. Dependent actions don't seem to have access to the required context for trusted publishing, for some reason.