### PR TITLE
Add JSDoc comments to the objectHelpers functions

### DIFF
--- a/src/functions/objectHelpers/getRecordKeys.ts
+++ b/src/functions/objectHelpers/getRecordKeys.ts
@@ -1,7 +1,18 @@
 import type { RecordKey } from "src/types";
 
-function getRecordKeys<T extends Record<RecordKey, unknown>>(record: T & object): (keyof T)[] {
-  return Object.keys(record) as (keyof T)[];
+/**
+ * Gets the keys from a given record object, properly typed to be an array of the key of the input object's type.
+ *
+ * @template InputRecordType - The type of the input object.
+ *
+ * @param record - The record to get the keys from.
+ *
+ * @returns An array with all the keys of the input object in string form, but properly typed as `keyof InputRecordType`.
+ */
+function getRecordKeys<InputRecordType extends Record<RecordKey, unknown>>(
+  record: InputRecordType & object,
+): (keyof InputRecordType)[] {
+  return Object.keys(record) as (keyof InputRecordType)[];
 }
 
 export default getRecordKeys;

--- a/src/functions/objectHelpers/omitProperties.ts
+++ b/src/functions/objectHelpers/omitProperties.ts
@@ -1,13 +1,27 @@
+/**
+ * Omits properties from a given object.
+ *
+ * @template ObjectType - The type of the input object.
+ * @template KeysToOmit - A type representing the keys to omit from the object.
+ *
+ * @param object - The object to omit properties from.
+ * @param keysToOmit - The keys to omit from the object. Can either be a single string to omit one, or an array to omit multiple.
+ *
+ * @returns An object with a new reference in memory, with the properties omitted.
+ */
 function omitProperties<
-  T extends Record<string, unknown> | Readonly<Record<string, unknown>>,
-  K extends keyof T,
->(object: T, keysToOmit: K | readonly K[]): Omit<T, K> {
+  ObjectType extends Record<string, unknown> | Readonly<Record<string, unknown>>,
+  KeysToOmit extends keyof ObjectType,
+>(
+  object: ObjectType,
+  keysToOmit: KeysToOmit | readonly KeysToOmit[],
+): Omit<ObjectType, KeysToOmit> {
   const outputObject: Record<string, unknown> = { ...object };
   const keysArray = Array.isArray(keysToOmit) ? keysToOmit : [keysToOmit];
   keysArray.forEach((key) => {
     delete outputObject[key];
   });
-  return outputObject as Omit<T, K>;
+  return outputObject as Omit<ObjectType, KeysToOmit>;
 }
 
 export default omitProperties;


### PR DESCRIPTION
This should provide a better developer experience for people using these shared components, as it gives usage information right there in the editor.