### PR TITLE
Add JSDoc comments to the stringHelpers functions

### DIFF
--- a/src/functions/stringHelpers/appendSemicolon.ts
+++ b/src/functions/stringHelpers/appendSemicolon.ts
@@ -1,3 +1,12 @@
+/**
+ * Appends a semicolon to the end of a string, trimming where necessary first.
+ *
+ * @param stringToAppendTo - The string to append a semicolon to.
+ *
+ * @throws {Error} If the string contains multiple lines.
+ *
+ * @returns A string with the semicolon appended.
+ */
 function appendSemicolon(stringToAppendTo: string): string {
   if (stringToAppendTo.includes("\n")) {
     throw new Error("MULTIPLE_LINE_ERROR");

--- a/src/functions/stringHelpers/camelToKebab.ts
+++ b/src/functions/stringHelpers/camelToKebab.ts
@@ -1,3 +1,10 @@
+/**
+ * Converts a string from camelCase to kebab-case
+ *
+ * @param string - The string to convert.
+ *
+ * @returns The string converted to kebab-case.
+ */
 function camelToKebab(string: string): string {
   return string
     .replace(/([a-z0-9])([A-Z])/g, "$1-$2")

--- a/src/functions/stringHelpers/kebabToCamel.ts
+++ b/src/functions/stringHelpers/kebabToCamel.ts
@@ -1,9 +1,18 @@
 import parseIntStrict from "src/functions/parsers/parseIntStrict";
 
 export interface KebabToCamelOptions {
+  /** Whether or not the converted string should start with an uppercase (e.g. CamelCase instead of camelCase). */
   startWithUpper?: boolean;
 }
 
+/**
+ * Converts a string from kebab-case to camelCase
+ *
+ * @param string - The string to convert.
+ * @param options - Options to apply to the conversion.
+ *
+ * @returns The string converted to camelCase.
+ */
 function kebabToCamel(string: string, options?: KebabToCamelOptions): string {
   if (string !== string.toLowerCase()) {
     throw new Error("INVALID_KEBAB_CASE_INPUT");

--- a/src/functions/stringHelpers/normalizeImportPath.ts
+++ b/src/functions/stringHelpers/normalizeImportPath.ts
@@ -1,5 +1,18 @@
 import path from "path";
 
+/**
+ * Normalizes an import path meant for use in an import statement in JavaScript.
+ *
+ * When multiple slashes are found, they're replaced by a single one; when the path contains a trailing slash, it is preserved. On Windows backslashes are used. If the path is a zero-length string, '.' is returned, representing the current working directory.
+ *
+ * If the path starts with ./, it is preserved (unlike what would happen with path.posix.normalize() normally).
+ *
+ * Helpful for custom linter rules that need to check (or fix) import paths.
+ *
+ * @param importPath - The import path to normalize.
+ *
+ * @returns The import path normalized.
+ */
 function normalizeImportPath(importPath: string): string {
   const normalizedPath = path.posix.normalize(importPath);
   if (importPath.startsWith("./") && !normalizedPath.startsWith("./")) {
@@ -8,6 +21,19 @@ function normalizeImportPath(importPath: string): string {
   return normalizedPath;
 }
 
+/**
+ * Normalises an import path meant for use in an import statement in JavaScript.
+ *
+ * When multiple slashes are found, they're replaced by a single one; when the path contains a trailing slash, it is preserved. On Windows backslashes are used. If the path is a zero-length string, '.' is returned, representing the current working directory.
+ *
+ * If the path starts with ./, it is preserved (unlike what would happen with path.posix.normalize() normally).
+ *
+ * Helpful for custom linter rules that need to check (or fix) import paths.
+ *
+ * @param importPath - The import path to normalise.
+ *
+ * @returns The import path normalised.
+ */
 export const normaliseImportPath = normalizeImportPath;
 
 export default normalizeImportPath;

--- a/src/functions/stringHelpers/truncate.ts
+++ b/src/functions/stringHelpers/truncate.ts
@@ -1,3 +1,11 @@
+/**
+ * Truncates a string and appends `...` to the end of it
+ *
+ * @param stringToTruncate - The string to truncate.
+ * @param maxLength - The length at which to start truncating. Note that this does not include the `...` part that would be appended.
+ *
+ * @returns A new string that has been truncated based on the length provided.
+ */
 function truncate(stringToTruncate: string, maxLength: number = 5): string {
   return stringToTruncate.length > maxLength
     ? `${stringToTruncate.slice(0, maxLength)}...`


### PR DESCRIPTION
This should provide a better developer experience for people using these shared components, as it gives usage information right there in the editor.