### PR TITLE
Add JSDoc comments to the miscellaneous functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "zod": "^4.1.13"
   },
   "devDependencies": {
-    "@alextheman/eslint-plugin": "^4.8.0",
+    "@alextheman/eslint-plugin": "^4.8.4",
     "@types/node": "^25.0.1",
     "dotenv-cli": "^11.0.0",
     "eslint": "^9.39.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ importers:
         version: 4.1.13
     devDependencies:
       '@alextheman/eslint-plugin':
-        specifier: ^4.8.0
-        version: 4.8.0(@eslint/js@9.39.1)(eslint-config-prettier@10.1.8(eslint@9.39.1))(eslint-import-resolver-typescript@4.4.4)(eslint-plugin-import@2.32.0)(eslint-plugin-jsdoc@61.5.0(eslint@9.39.1))(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.1))(eslint-plugin-package-json@0.85.0(@types/estree@1.0.8)(eslint@9.39.1)(jsonc-eslint-parser@2.4.2))(eslint-plugin-perfectionist@4.15.1(eslint@9.39.1)(typescript@5.9.3))(eslint-plugin-prettier@5.5.4(eslint-config-prettier@10.1.8(eslint@9.39.1))(eslint@9.39.1)(prettier@3.7.4))(eslint-plugin-react-hooks@7.0.1(eslint@9.39.1))(eslint-plugin-react-refresh@0.4.24(eslint@9.39.1))(eslint-plugin-react@7.37.5(eslint@9.39.1))(eslint@9.39.1)(typescript-eslint@8.49.0(eslint@9.39.1)(typescript@5.9.3))(typescript@5.9.3)(vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@7.2.7(@types/node@25.0.1)))(vitest@4.0.15(@types/node@25.0.1)(jsdom@27.3.0(postcss@8.5.6)))
+        specifier: ^4.8.4
+        version: 4.8.4(@eslint/js@9.39.1)(eslint-config-prettier@10.1.8(eslint@9.39.1))(eslint-import-resolver-typescript@4.4.4)(eslint-plugin-import@2.32.0)(eslint-plugin-jsdoc@61.5.0(eslint@9.39.1))(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.1))(eslint-plugin-package-json@0.85.0(@types/estree@1.0.8)(eslint@9.39.1)(jsonc-eslint-parser@2.4.2))(eslint-plugin-perfectionist@4.15.1(eslint@9.39.1)(typescript@5.9.3))(eslint-plugin-prettier@5.5.4(eslint-config-prettier@10.1.8(eslint@9.39.1))(eslint@9.39.1)(prettier@3.7.4))(eslint-plugin-react-hooks@7.0.1(eslint@9.39.1))(eslint-plugin-react-refresh@0.4.25(eslint@9.39.1))(eslint-plugin-react@7.37.5(eslint@9.39.1))(eslint@9.39.1)(typescript-eslint@8.49.0(eslint@9.39.1)(typescript@5.9.3))(typescript@5.9.3)(vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@7.2.7(@types/node@25.0.1)))(vitest@4.0.15(@types/node@25.0.1)(jsdom@27.3.0(postcss@8.5.6)))
       '@types/node':
         specifier: ^25.0.1
         version: 25.0.1
@@ -54,8 +54,8 @@ packages:
   '@acemir/cssom@0.9.29':
     resolution: {integrity: sha512-G90x0VW+9nW4dFajtjCoT+NM0scAfH9Mb08IcjgFHYbfiL/lU04dTF9JuVOi3/OH+DJCQdcIseSXkdCB9Ky6JA==}
 
-  '@alextheman/eslint-plugin@4.8.0':
-    resolution: {integrity: sha512-NjcGQEkEn9FxQxDpkSMxZYrrMvsmxEpOKyzhGeDzqY12hHqOchggmsSBRAQQM7mrzEIU5xoHQ+IfmfMuhf03lQ==}
+  '@alextheman/eslint-plugin@4.8.4':
+    resolution: {integrity: sha512-8orfUWrrHn72YssZj0RhXR7nOcReFzcUWDEggdjhGVMOvuKRfmz/BaScLWlJXL8rYuZGaowJJwQowmBMBy1uwg==}
     peerDependencies:
       '@eslint/js': '>=9.0.0'
       eslint: '>=9.0.0'
@@ -74,8 +74,8 @@ packages:
       vite-tsconfig-paths: '>=5.1.4'
       vitest: '>=4.0.13'
 
-  '@alextheman/utility@3.5.8':
-    resolution: {integrity: sha512-El967cw88wPp/hhX88oBpXk3kXcZY1+IgnXFv8iYavZ1I+6mN9T8OxD9akuU9nTLnxqcMaq0h3ho7abWcTNI1A==}
+  '@alextheman/utility@3.6.0':
+    resolution: {integrity: sha512-sEs/8WaOnwO0YzzcrxWlcOSPKg2yZq4RGaxnR9T9BxS+RUF7DIrrH1IGH8leSAtZ9khwy98qv5Ne5Ui2dC35+g==}
 
   '@altano/repository-tools@2.0.1':
     resolution: {integrity: sha512-YE/52CkFtb+YtHPgbWPai7oo5N9AKnMuP5LM+i2AG7G1H2jdYBCO1iDnkDE3dZ3C1MIgckaF+d5PNRulgt0bdw==}
@@ -1327,8 +1327,8 @@ packages:
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
 
-  eslint-plugin-react-refresh@0.4.24:
-    resolution: {integrity: sha512-nLHIW7TEq3aLrEYWpVaJ1dRgFR+wLDPN8e8FpYAql/bMV2oBEfC37K0gLEGgv9fy66juNShSMV8OkTqzltcG/w==}
+  eslint-plugin-react-refresh@0.4.25:
+    resolution: {integrity: sha512-dRUD2LOdEqI4zXHqbQ442blQAzdSuShAaiSq5Vtyy6LT08YUf0oOjBDo4VPx0dCPgiPWh1WB4dtbLOd0kOlDPQ==}
     peerDependencies:
       eslint: '>=8.40'
 
@@ -2087,8 +2087,8 @@ packages:
   sort-object-keys@2.0.1:
     resolution: {integrity: sha512-R89fO+z3x7hiKPXX5P0qim+ge6Y60AjtlW+QQpRozrrNcR1lw9Pkpm5MLB56HoNvdcLHL4wbpq16OcvGpEDJIg==}
 
-  sort-package-json@3.5.1:
-    resolution: {integrity: sha512-LfwyHQuTnJ3336Sexi6yDz1QxvSjXKbc78pOw2HQy8BJHFXzONu+zLvLald0NpLWM0exsYyI7M8PeJAngNgpbA==}
+  sort-package-json@3.6.0:
+    resolution: {integrity: sha512-fyJsPLhWvY7u2KsKPZn1PixbXp+1m7V8NWqU8CvgFRbMEX41Ffw1kD8n0CfJiGoaSfoAvbrqRRl/DcHO8omQOQ==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -2522,9 +2522,9 @@ snapshots:
 
   '@acemir/cssom@0.9.29': {}
 
-  '@alextheman/eslint-plugin@4.8.0(@eslint/js@9.39.1)(eslint-config-prettier@10.1.8(eslint@9.39.1))(eslint-import-resolver-typescript@4.4.4)(eslint-plugin-import@2.32.0)(eslint-plugin-jsdoc@61.5.0(eslint@9.39.1))(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.1))(eslint-plugin-package-json@0.85.0(@types/estree@1.0.8)(eslint@9.39.1)(jsonc-eslint-parser@2.4.2))(eslint-plugin-perfectionist@4.15.1(eslint@9.39.1)(typescript@5.9.3))(eslint-plugin-prettier@5.5.4(eslint-config-prettier@10.1.8(eslint@9.39.1))(eslint@9.39.1)(prettier@3.7.4))(eslint-plugin-react-hooks@7.0.1(eslint@9.39.1))(eslint-plugin-react-refresh@0.4.24(eslint@9.39.1))(eslint-plugin-react@7.37.5(eslint@9.39.1))(eslint@9.39.1)(typescript-eslint@8.49.0(eslint@9.39.1)(typescript@5.9.3))(typescript@5.9.3)(vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@7.2.7(@types/node@25.0.1)))(vitest@4.0.15(@types/node@25.0.1)(jsdom@27.3.0(postcss@8.5.6)))':
+  '@alextheman/eslint-plugin@4.8.4(@eslint/js@9.39.1)(eslint-config-prettier@10.1.8(eslint@9.39.1))(eslint-import-resolver-typescript@4.4.4)(eslint-plugin-import@2.32.0)(eslint-plugin-jsdoc@61.5.0(eslint@9.39.1))(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.1))(eslint-plugin-package-json@0.85.0(@types/estree@1.0.8)(eslint@9.39.1)(jsonc-eslint-parser@2.4.2))(eslint-plugin-perfectionist@4.15.1(eslint@9.39.1)(typescript@5.9.3))(eslint-plugin-prettier@5.5.4(eslint-config-prettier@10.1.8(eslint@9.39.1))(eslint@9.39.1)(prettier@3.7.4))(eslint-plugin-react-hooks@7.0.1(eslint@9.39.1))(eslint-plugin-react-refresh@0.4.25(eslint@9.39.1))(eslint-plugin-react@7.37.5(eslint@9.39.1))(eslint@9.39.1)(typescript-eslint@8.49.0(eslint@9.39.1)(typescript@5.9.3))(typescript@5.9.3)(vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@7.2.7(@types/node@25.0.1)))(vitest@4.0.15(@types/node@25.0.1)(jsdom@27.3.0(postcss@8.5.6)))':
     dependencies:
-      '@alextheman/utility': 3.5.8
+      '@alextheman/utility': 3.6.0
       '@eslint/js': 9.39.1
       '@typescript-eslint/utils': 8.49.0(eslint@9.39.1)(typescript@5.9.3)
       common-tags: 1.8.2
@@ -2539,7 +2539,7 @@ snapshots:
       eslint-plugin-prettier: 5.5.4(eslint-config-prettier@10.1.8(eslint@9.39.1))(eslint@9.39.1)(prettier@3.7.4)
       eslint-plugin-react: 7.37.5(eslint@9.39.1)
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.1)
-      eslint-plugin-react-refresh: 0.4.24(eslint@9.39.1)
+      eslint-plugin-react-refresh: 0.4.25(eslint@9.39.1)
       typescript-eslint: 8.49.0(eslint@9.39.1)(typescript@5.9.3)
       vite-tsconfig-paths: 5.1.4(typescript@5.9.3)(vite@7.2.7(@types/node@25.0.1))
       vitest: 4.0.15(@types/node@25.0.1)(jsdom@27.3.0(postcss@8.5.6))
@@ -2548,7 +2548,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@alextheman/utility@3.5.8':
+  '@alextheman/utility@3.6.0':
     dependencies:
       zod: 4.1.13
 
@@ -3798,7 +3798,7 @@ snapshots:
       package-json-validator: 0.59.0
       semver: 7.7.3
       sort-object-keys: 2.0.1
-      sort-package-json: 3.5.1
+      sort-package-json: 3.6.0
       validate-npm-package-name: 7.0.0
     transitivePeerDependencies:
       - '@types/estree'
@@ -3833,7 +3833,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-refresh@0.4.24(eslint@9.39.1):
+  eslint-plugin-react-refresh@0.4.25(eslint@9.39.1):
     dependencies:
       eslint: 9.39.1
 
@@ -4690,7 +4690,7 @@ snapshots:
 
   sort-object-keys@2.0.1: {}
 
-  sort-package-json@3.5.1:
+  sort-package-json@3.6.0:
     dependencies:
       detect-indent: 7.0.2
       detect-newline: 4.0.1

--- a/src/functions/miscellaneous/convertFileToBase64.ts
+++ b/src/functions/miscellaneous/convertFileToBase64.ts
@@ -1,3 +1,12 @@
+/**
+ * Asynchronously converts a file to a base 64 string
+ *
+ * @param file - The file to convert.
+ *
+ * @throws {Error} If the file reader gives an error.
+ *
+ * @returns A promise that resolves to the encoded base 64 string.
+ */
 function convertFileToBase64(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();

--- a/src/functions/miscellaneous/getRandomNumber.ts
+++ b/src/functions/miscellaneous/getRandomNumber.ts
@@ -1,5 +1,13 @@
 import parseIntStrict from "src/functions/parsers/parseIntStrict";
 
+/**
+ * Gets a random number between the given bounds.
+ *
+ * @param lowerBound - The lowest number that can be chosen.
+ * @param upperBound - The highest number that can be chosen.
+ *
+ * @returns A random number between the provided lower bound and upper bound.
+ */
 function getRandomNumber(lowerBound: number, upperBound: number): number {
   const parsedLowerBound = parseIntStrict(`${lowerBound}`);
   const parsedUpperBound = parseIntStrict(`${upperBound}`);

--- a/src/functions/miscellaneous/isOrdered.ts
+++ b/src/functions/miscellaneous/isOrdered.ts
@@ -1,4 +1,11 @@
-function isOrdered(array: readonly number[] | number[]): boolean {
+/**
+ * Checks to see if the given array is sorted in ascending order.
+ *
+ * @param array - The array to check.
+ *
+ * @returns `true` if the array is sorted in ascending order, and `false` otherwise.
+ */
+function isOrdered(array: readonly number[]): boolean {
   const newArray = [...array];
   newArray.sort();
 

--- a/src/functions/miscellaneous/stringListToArray.ts
+++ b/src/functions/miscellaneous/stringListToArray.ts
@@ -1,8 +1,20 @@
 export interface StringListToArrayOptions {
+  /** What each item in the list is separated by. */
   separator?: string;
+  /** An option to trim any extra whitespace. */
   trimWhitespace?: boolean;
 }
 
+/**
+ * Converts a stringly-typed list to a proper array.
+ *
+ * @param stringList - The stringly-typed list to convert.
+ * @param options - The options to apply to the conversion.
+ * @param options.separator - What each item in the list is separated by.
+ * @param options.trimWhitespace - An option to trim any extra whitespace.
+ *
+ * @returns A new array with each item being an item from the given list.
+ */
 function stringListToArray(
   stringList: string,
   { separator = ",", trimWhitespace = true }: StringListToArrayOptions = {},

--- a/src/functions/miscellaneous/wait.ts
+++ b/src/functions/miscellaneous/wait.ts
@@ -1,3 +1,10 @@
+/**
+ * Waits for the given number of seconds
+ *
+ * @param seconds - The number of seconds to wait.
+ *
+ * @returns A Promise that resolves after the given number of seconds.
+ */
 function wait(seconds: number): Promise<void> {
   return new Promise<void>((resolve, _) => {
     setTimeout(() => {


### PR DESCRIPTION
This should provide a better developer experience for people using these shared components, as it gives usage information right there in the editor.

Also note that I had to update ESLint plugin to allow the note tag in the createFormData JSDoc comments.