### PR TITLE
Change version number to v4.0.0

### DIFF
--- a/docs/releases/major/v4.0.0.md
+++ b/docs/releases/major/v4.0.0.md
@@ -1,6 +1,6 @@
 # v4.0.0 (Major Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new major release of the `@alextheman/utility` package. It has the potential to introduce breaking changes that may require a large amount of refactoring. Please read the below description of changes and migration notes for more information.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alextheman/utility",
-  "version": "3.10.1",
+  "version": "4.0.0",
   "description": "Helpful utility functions",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# v4.0.0 (Major Release)

**Status**: Released

This is a new major release of the `@alextheman/utility` package. It has the potential to introduce breaking changes that may require a large amount of refactoring. Please read the below description of changes and migration notes for more information.

## Description of Changes

- Removes deprecated features from the package (see below).
- Changes the implementation of `DataError` a bit, and uses it more frequently in parsers. If you rely on parser functions or catch errors programmatically, you should
review the `DataError` changes carefully, as this affects both error types and
constructor usage.
- Not necessarily part of this release explicitly (it came in v3.9.0), but given that that doesn't have any release notes as they were introduced after that release, I'll mention again that we now have JSDoc comments!
- We will also officially have a MIT License for the package.

## Migration Notes

### Deprecations

`stringToBoolean`:
- Please use `parseBoolean` from this package instead.

`removeIndents`:
- Please use `normaliseIndents` or `normalizeIndents` from this package instead.

`parseEmail`:
- You can get the Zod schema associated with this function using `z.email().brand<"Email">()`, and infer the type and get the parser separately.
- Given how trivial it is to recreate this, I figured it is no longer worth keeping and maintaining as it adds no real extra benefit to what Zod already does.

`parseUUID`:
- Same as above, but use `z.uuid().brand<"UUID">()`.
- Alternatively, the crypto package from Node already comes with a UUID type that is more accurate to what an actual UUID should be like.

`DeepReadonly`:
- This type is deprecated because it did not work with `deepFreeze` as intended. Please do not use this type at all.
- You can still use deepFreeze to deeply freeze objects at runtime, but the type will be `Readonly<ObjectType>`.

### Parser/DataError changes

`DataError`:
- The `code` and `message` properties have been swapped around in the constructor argument. That is instead of doing `new DataError(data, message, code)`, you now do `new DataError(data, code, message)`.
- I know most of you are going to hate me for this because it will break a lot of existing implementations, but it honestly does read better to me when the standardised code comes before the message. That way, we decide on the specific type of `DataError` with the code, then we use that to help decide the human-readable error message.
- This error type is also expected to be used across most of my parsers from this point on. As such, for the most part, if the error handling in the parsers end up breaking as a result of this update, it's because you need to catch a `DataError` now. More specific changes below.

`parseEnv`:
- If you're catching the error and expecting it to be a `ZodError`, note that it will be a `DataError` from this point on.
- The code provided by the `DataError` will be `"INVALID_ENV`, which should help you narrow down the specific type of `DataError`.
- This is done to avoid tying the function too closely to its internal implementation. It is better to throw my own custom error so consumers depend on this package's tooling for the error handling of its own parsers rather than that of an internal dependency. It also provides more flexibility in case I want to migrate away from Zod in the future (which does seem unlikely as of now, but I still think it's good practice not to expose external errors too much).

`parseIntStrict`:
- We have moved away from throwing a `TypeError` to a `DataError`.
- The error message can now also directly explain exactly what the issue is, which is nice (i.e. out of range given the radix, disallowed characters...).
- This one benefits the most from `DataError`, I feel. That said, if you look at the source code, have fun looking at the implementation behind how I conditionally show the message `"Only numeric values are allowed."` as opposed to `"Only numeric values or characters A-F are allowed."`! It's intense...

`parseVersionType`:
- Previously it threw a `DataError`, and now it still does.
- The difference this time is that the code thrown will now always be `INVALID_VERSION_TYPE`, so you can use that to catch it rather than the generic `INVALID_DATA`

`parseZodSchema`:
- It now takes an additional optional `error` argument, which allows you to provide your own error to throw in case of invalid data.
- If left out, it will default to a `DataError` with the default `INVALID_DATA` code.
- For my use cases, I will generally be passing in my own `DataError` to further customise the code and message per usage.
