### PR TITLE
Add a pull request template for any changes that are not yet part of a release

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/breaking_change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/breaking_change.md
@@ -1,0 +1,5 @@
+# Breaking Change
+
+This is a change to `@alextheman/utility` that will cause breaking changes wherever it is used.
+
+Please see the commits tab of this pull request for the description of changes.

--- a/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
@@ -1,0 +1,5 @@
+# Bug Fix
+
+This is a bug fix for `@alextheman/utility`. It fixes an unintended side-effect of the package.
+
+Please see the commits tab of this pull request for the description of changes.

--- a/.github/PULL_REQUEST_TEMPLATE/documentation_change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/documentation_change.md
@@ -1,0 +1,5 @@
+# Documentation Change
+
+This is a change to the documentation of `@alextheman/utility`. It changes the way that information about the package is presented to users.
+
+Please see the commits tab of this pull request for the description of changes.

--- a/.github/PULL_REQUEST_TEMPLATE/miscellaneous.md
+++ b/.github/PULL_REQUEST_TEMPLATE/miscellaneous.md
@@ -1,0 +1,5 @@
+# Miscellaneous
+
+This is a general change to `@alextheman/utility` that does not fit in any of the other provided categories.
+
+Please see the commits tab of this pull request for the description of changes.

--- a/.github/PULL_REQUEST_TEMPLATE/new_feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new_feature.md
@@ -1,0 +1,5 @@
+# New Feature
+
+This is a new feature for `@alextheman/utility`. It adds a new feature to the package.
+
+Please see the commits tab of this pull request for the description of changes.

--- a/.github/PULL_REQUEST_TEMPLATE/refactor.md
+++ b/.github/PULL_REQUEST_TEMPLATE/refactor.md
@@ -1,0 +1,5 @@
+# Refactor
+
+This is a change to the code layout of `@alextheman/utility`. It changes how the code is presented in terms of quality and structure without changing its overall runtime behaviour or user-facing functionality.
+
+Please see the commits tab of this pull request for the description of changes.

--- a/.github/PULL_REQUEST_TEMPLATE/tooling_change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/tooling_change.md
@@ -1,0 +1,5 @@
+# Tooling Change
+
+This is a change to the tooling of `@alextheman/utility`. It changes the internal workings of the package that should have no noticeable effect on users.
+
+Please see the commits tab of this pull request for the description of changes.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+# Select a Template
+
+Please select the option that best describes your changes:
+
+- [Breaking Change](?template=breaking_change.md) - For changes that may require users of the package to refactor their code.
+- [New Feature](?template=new_feature.md) - For changes that add a new feature to the package.
+- [Bug Fix](?template=bug_fix.md) - For changes that fix a bug in the package.
+- [Tooling Change](?template=tooling_change.md) - For changes to the package's tooling (dependencies, devDependencies, configs...).
+- [Documentation Change](?template=documentation_change.md) - For changes that affect the way that information about the package is presented to users.
+- [Refactor](?template=refactor.md) - For changes that change code quality and structure without affecting runtime behaviour.
+- [Miscellaneous](?template=miscellaneous.md) - For changes that do not fit cleanly into any of the above categories.
+
+In some cases, your pull request may be doing more than one of these. In this case, please select a template from the top-down.
+For example, if you are introducing a new feature but also making changes to tooling, please select `New Feature` as that comes before tooling in the list.


### PR DESCRIPTION
This also allows us to categorise changes better, as the pull request message better describes the high-level intent behind the changes made.

Note that there may be some grey area in practice, in which case templates should be selected from the top-down.

# Documentation Change

This is a change to the documentation of `@alextheman/utility`. It changes the way that information about the package is presented to users.

Please see the commits tab of this pull request for the description of changes.
