### PR TITLE
Change version number to v3.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alextheman/utility",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Helpful utility functions",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# v3.8.0 (Minor Release)

This is a new minor release of the `@alextheman/utility` package. It introduces new features in a backwards-compatible way that should require very little refactoring, if any. Please read below the description of changes.

## Description of Changes

- Adds three new helpers to help with versioning:
    - `parseVersion`
        - Verifies that a given string matches a valid software version, and normalizes it to start with `v` (unless `omitPrefix: true` is set in options)
    - `getIndividualVersionNumbers`
        - Gets the individual version numbers from a given version number, returned in a `[major, minor, patch]` tuple.
    - `determineVersionType`
        - Determine if the given version is a major, minor, or patch version.
        - Version type rules:
            - **Major**: minor and patch are both zero.
            - **Minor**: patch is zero.
            - **Patch**: any other case.

## Additional Notes

- These helpers are additive and backwards-compatible, so upgrading to v3.8.0 should not require any changes to existing code.
- These are expected to be used in the new versioning pattern, where release docs like this can be generated automatically by AlexCLine.
