### PR TITLE
Change version number to v3.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alextheman/utility",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "description": "Helpful utility functions",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# v3.10.0 (Minor Release)

**Status**: Released

This is a new minor release of the `@alextheman/utility` package. It introduces new features in a backwards-compatible way that should require very little refactoring, if any. Please read below the description of changes.

## Description of Changes

- Moves the `VersionType` type from `src/types` to `src/functions/parsers/parseVersionType.ts`.
- Adds a parser in that file to go along with that type.
- The type is also now inferred from a Zod schema to maintain the single source of truth between type and parser.
- Fixes a weird bug in the `parseIntStrict` JSDoc comment where we had a double-dash next to the string param display in the editor, for some reason.

## Additional Notes

-  `parseVersionType` is expected to be used in AlexCLine's version release notes generator, so that we can pass in a version type as well to generate the docs for the next version up from `package.json`.
- Also note that `parseVersionType` throws a `DataError` instead of a `ZodError`. This is intentional and makes use of my new `DataError` class. I intend to eventually change `parseEnv` to follow a similar pattern and throw a `DataError` instead as well, but I will defer that for the major version release.
