### PR TITLE
Add an emergency create-github-release workflow

### DIFF
--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -1,0 +1,15 @@
+name: Create GitHub Release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  create-github-release:
+    if: ${{ github.repository == 'alextheman231/utility' }}
+    uses: alextheman231/github-actions/.github/workflows/create-github-release.yml@84fe032bc2c67a442beaae6648323087929d34c0 # v11.0.7
+    secrets:
+      APP_ID: ${{ secrets.ALEX_UP_BOT_APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.ALEX_UP_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
We need this to quickly recover from the interrupted publish workflow and complete release v5.11.0.

# Tooling Change

This is a change to the tooling of `@alextheman/utility`. It changes the internal workings of the package and should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
