### PR TITLE
Add a test to verify the error function does not get called if the pa…

### DIFF
--- a/tests/functions/parsers/parseZodSchema.test.ts
+++ b/tests/functions/parsers/parseZodSchema.test.ts
@@ -41,7 +41,7 @@ describe("parseZodSchema", () => {
       }
     }
   });
-  test("The error function can return nothing", () => {
+  test("The error function can return nothing but still gets run if an error is expected", () => {
     let wasCalled = false;
     const error = DataError.expectError(() => {
       parseZodSchema(z.string(), 1, () => {
@@ -52,6 +52,15 @@ describe("parseZodSchema", () => {
     expect(wasCalled).toBe(true);
     expect(error.data.input).toBe(1);
     expect(error.code).toBe("INVALID_TYPE");
+  });
+  test("The error function must not be run if parsing was successful", () => {
+    let wasCalled = false;
+    const result = parseZodSchema(z.string(), "hello", () => {
+      wasCalled = true;
+    });
+
+    expect(wasCalled).toBe(false);
+    expect(result).toBe("hello");
   });
   test("If multiple Zod errors found, the error code should be a comma-separated string list sorted by frequency", () => {
     const input = {


### PR DESCRIPTION
…rsing was successful

This should've been added initially, but I forgot to add it. This ensures that the error function does not get accidentally run even if parsing succeeded.

# Tooling Change

This is a change to the tooling of `@alextheman/utility`. It changes the internal workings of the package and should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
