### PR TITLE
Skip internal NPM entrypoint tests

### DIFF
--- a/tests/end-to-end/entrypoints.test.ts
+++ b/tests/end-to-end/entrypoints.test.ts
@@ -1,4 +1,3 @@
-import type { PackageManager } from "src/internal";
 import type { CreateEnumType } from "src/root/types";
 
 import { temporaryDirectoryTask } from "tempy";
@@ -12,6 +11,7 @@ import {
   getPackageJsonContents,
   ModuleType,
   packageJsonNotFoundError,
+  PackageManager,
   setupPackageEndToEnd,
 } from "src/internal";
 import { normaliseIndents, omitProperties, parseBoolean } from "src/root/functions";
@@ -82,6 +82,10 @@ describe.each<Entrypoint>([Entrypoint.ROOT, Entrypoint.NODE, Entrypoint.INTERNAL
       test.each<ModuleType>(["commonjs", "module", "typescript"])(
         "Module type %s",
         async (moduleType) => {
+          if (packageManager === PackageManager.NPM && entrypoint === Entrypoint.INTERNAL) {
+            console.info("Skipping test...");
+            return;
+          }
           const code = getRuntimeCodeString(moduleType, entrypoint);
 
           await temporaryDirectoryTask(async (temporaryPath) => {


### PR DESCRIPTION
The internal entrypoint is meant more for internal usage, and all of my internal usage uses PNPM rather than NPM. As such, I think it's best to skip those as they just add more CI time with no benefit.

# Tooling Change

This is a change to the tooling of `@alextheman/utility`. It changes the internal workings of the package and should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
