### PR TITLE
Fix weird bug in release note generation

### DIFF
--- a/docs/releases/v5/v5.24/v5.24.0.md
+++ b/docs/releases/v5/v5.24/v5.24.0.md
@@ -15,19 +15,6 @@ This is a new minor release of the `@alextheman/utility` package. It introduces 
   - `UUID_PATTERN` -> `UUID_REGEX_PATTERN`
   - `VERSION_NUMBER_PATTERN` -> `VERSION_NUMBER_REGEX_PATTERN`
   - `FILE_PATH_PATTERN` -> `FILE_PATH_REGEX_PATTERN`
-- Change `VERSION_NUMBER_REGEX_PATTERN` to be just the pattern rather than anchoring it with `^` and `# v5.24.0 (Minor Release)
-
-<!-- alex-c-line-release-status-start -->
-**Status**: Released
-<!-- alex-c-line-release-status-end -->
-
-<!-- alex-c-line-release-summary-start -->
-This is a new minor release of the `@alextheman/utility` package. It introduces new features and other backwards-compatible changes that should require little to no refactoring. Please read the description of changes below.
-<!-- alex-c-line-release-summary-end -->
-
-## Description of Changes
-
-<!-- user-editable-section-start -->
-.
+- Change `VERSION_NUMBER_REGEX_PATTERN` to be just the pattern rather than anchoring it with `^` and `$`
   - This allows it to be composed into other regexes more easily.
 <!-- user-editable-section-end -->


### PR DESCRIPTION
For some reason set-status seems to have messed with the formatting of the release note.

My guess is because of the `$` in the release note. That may've potentially thrown it off somehow due to parsing issues? I will have to investigate at some point.

# Documentation Change

This is a change to the documentation of `@alextheman/utility`. It changes the way that information about the package is presented to users.

Please see the commits tab of this pull request for the description of changes.
