### PR TITLE
Use Node v26 in CI

### DIFF
--- a/.github/workflows/audit-javascript-dependencies.yml
+++ b/.github/workflows/audit-javascript-dependencies.yml
@@ -11,9 +11,10 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: alextheman231/github-actions/.github/workflows/audit-javascript-dependencies.yml@0776a9d83e56a216f52b56cb87ec0ff8f84a9368 # v12.3.0
+    uses: alextheman231/github-actions/.github/workflows/audit-javascript-dependencies.yml@beff06a63619c0122aeeca38b9cd48bf09f70cc9 # v12.4.0
     with:
       pull-request-number: ${{ github.event.pull_request.number }}
+      node-version: 26
       APP_ID: ${{ vars.ALEX_UP_BOT_APP_ID }}
     secrets:
       APP_PRIVATE_KEY: ${{ secrets.ALEX_UP_BOT_PRIVATE_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,14 @@ permissions:
 
 jobs:
   package-ci:
-    uses: alextheman231/github-actions/.github/workflows/package-ci.yml@0776a9d83e56a216f52b56cb87ec0ff8f84a9368 # v12.3.0
+    uses: alextheman231/github-actions/.github/workflows/package-ci.yml@beff06a63619c0122aeeca38b9cd48bf09f70cc9 # v12.4.0
+    with:
+      node-version: 26
 
   actions-ci:
-    uses: alextheman231/github-actions/.github/workflows/actions-ci.yml@0776a9d83e56a216f52b56cb87ec0ff8f84a9368 # v12.3.0
+    uses: alextheman231/github-actions/.github/workflows/actions-ci.yml@beff06a63619c0122aeeca38b9cd48bf09f70cc9 # v12.4.0
 
   end-to-end-ci:
-    uses: alextheman231/github-actions/.github/workflows/end-to-end-node-package-ci.yml@0776a9d83e56a216f52b56cb87ec0ff8f84a9368 # v12.3.0
+    uses: alextheman231/github-actions/.github/workflows/end-to-end-node-package-ci.yml@beff06a63619c0122aeeca38b9cd48bf09f70cc9 # v12.4.0
+    with:
+      node-version: 26

--- a/.github/workflows/commit-version-change.yml
+++ b/.github/workflows/commit-version-change.yml
@@ -9,9 +9,10 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: alextheman231/github-actions/.github/workflows/commit-version-change.yml@0776a9d83e56a216f52b56cb87ec0ff8f84a9368 # v12.3.0
+    uses: alextheman231/github-actions/.github/workflows/commit-version-change.yml@beff06a63619c0122aeeca38b9cd48bf09f70cc9 # v12.4.0
     with:
       version-type: major
+      node-version: 26
     secrets:
       APP_ID: ${{ vars.ALEX_UP_BOT_APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.ALEX_UP_BOT_PRIVATE_KEY}}
@@ -20,9 +21,10 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: alextheman231/github-actions/.github/workflows/commit-version-change.yml@0776a9d83e56a216f52b56cb87ec0ff8f84a9368 # v12.3.0
+    uses: alextheman231/github-actions/.github/workflows/commit-version-change.yml@beff06a63619c0122aeeca38b9cd48bf09f70cc9 # v12.4.0
     with:
       version-type: minor
+      node-version: 26
     secrets:
       APP_ID: ${{ vars.ALEX_UP_BOT_APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.ALEX_UP_BOT_PRIVATE_KEY}}
@@ -31,9 +33,10 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: alextheman231/github-actions/.github/workflows/commit-version-change.yml@0776a9d83e56a216f52b56cb87ec0ff8f84a9368 # v12.3.0
+    uses: alextheman231/github-actions/.github/workflows/commit-version-change.yml@beff06a63619c0122aeeca38b9cd48bf09f70cc9 # v12.4.0
     with:
       version-type: patch
+      node-version: 26
     secrets:
       APP_ID: ${{ vars.ALEX_UP_BOT_APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.ALEX_UP_BOT_PRIVATE_KEY}}

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -9,7 +9,9 @@ permissions:
 jobs:
   create-github-release:
     if: ${{ github.repository == 'alextheman231/utility' }}
-    uses: alextheman231/github-actions/.github/workflows/create-github-release.yml@0776a9d83e56a216f52b56cb87ec0ff8f84a9368 # v12.3.0
+    uses: alextheman231/github-actions/.github/workflows/create-github-release.yml@beff06a63619c0122aeeca38b9cd48bf09f70cc9 # v12.4.0
+    with:
+      node-version: 26
     secrets:
       APP_ID: ${{ vars.ALEX_UP_BOT_APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.ALEX_UP_BOT_PRIVATE_KEY }}

--- a/.github/workflows/create-pull-request-templates.yml
+++ b/.github/workflows/create-pull-request-templates.yml
@@ -12,7 +12,9 @@ permissions:
 jobs:
   create-pull-request-templates:
     if: ${{ github.repository == 'alextheman231/utility' }}
-    uses: alextheman231/github-actions/.github/workflows/create-pull-request-templates.yml@0776a9d83e56a216f52b56cb87ec0ff8f84a9368 # v12.3.0
+    uses: alextheman231/github-actions/.github/workflows/create-pull-request-templates.yml@beff06a63619c0122aeeca38b9cd48bf09f70cc9 # v12.4.0
+    with:
+      node-version: 26
     secrets:
       APP_ID: ${{ vars.ALEX_UP_BOT_APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.ALEX_UP_BOT_PRIVATE_KEY }}

--- a/.github/workflows/publish-github-pages.yml
+++ b/.github/workflows/publish-github-pages.yml
@@ -7,10 +7,11 @@ jobs:
     permissions:
       pages: write
       id-token: write
-    uses: alextheman231/github-actions/.github/workflows/publish-github-pages.yml@0776a9d83e56a216f52b56cb87ec0ff8f84a9368 # v12.3.0
+    uses: alextheman231/github-actions/.github/workflows/publish-github-pages.yml@beff06a63619c0122aeeca38b9cd48bf09f70cc9 # v12.4.0
     secrets:
       APP_ID: ${{ vars.ALEX_UP_BOT_APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.ALEX_UP_BOT_PRIVATE_KEY }}
     with:
       path: docs/features/html
       build-configs: true
+      node-version: 26

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,14 +10,18 @@ jobs:
     permissions:
       id-token: write
     if: ${{ github.repository == 'alextheman231/utility' }}
-    uses: alextheman231/github-actions/.github/workflows/npm-registry-publish.yml@bdfeb2c0a2a5f45212484144896e95a2c7c89bc6 # v12.3.1
+    uses: alextheman231/github-actions/.github/workflows/npm-registry-publish.yml@beff06a63619c0122aeeca38b9cd48bf09f70cc9 # v12.4.0
+    with:
+      node-version: 26
 
   create-github-release:
     needs: npm-registry-publish
     permissions:
       contents: write
     if: needs.npm-registry-publish.outputs.did_publish == 'true'
-    uses: alextheman231/github-actions/.github/workflows/create-github-release.yml@0776a9d83e56a216f52b56cb87ec0ff8f84a9368 # v12.3.0
+    uses: alextheman231/github-actions/.github/workflows/create-github-release.yml@beff06a63619c0122aeeca38b9cd48bf09f70cc9 # v12.4.0
+    with:
+      node-version: 26
     secrets:
       APP_ID: ${{ vars.ALEX_UP_BOT_APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.ALEX_UP_BOT_PRIVATE_KEY }}
@@ -28,10 +32,11 @@ jobs:
       id-token: write
     needs: create-github-release
     if: needs.create-github-release.outputs.did_release == 'true'
-    uses: alextheman231/github-actions/.github/workflows/publish-github-pages.yml@0776a9d83e56a216f52b56cb87ec0ff8f84a9368 # v12.3.0
+    uses: alextheman231/github-actions/.github/workflows/publish-github-pages.yml@beff06a63619c0122aeeca38b9cd48bf09f70cc9 # v12.4.0
     secrets:
       APP_ID: ${{ vars.ALEX_UP_BOT_APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.ALEX_UP_BOT_PRIVATE_KEY }}
     with:
       path: docs/features/html
       build-configs: true
+      node-version: 26

--- a/.github/workflows/restrict-alex-up-bot-branches.yml
+++ b/.github/workflows/restrict-alex-up-bot-branches.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   restrict-alex-up-bot-branches:
-    uses: alextheman231/github-actions/.github/workflows/restrict-alex-up-bot-branches.yml@0776a9d83e56a216f52b56cb87ec0ff8f84a9368 # v12.3.0
+    uses: alextheman231/github-actions/.github/workflows/restrict-alex-up-bot-branches.yml@beff06a63619c0122aeeca38b9cd48bf09f70cc9 # v12.4.0
     secrets:
       APP_ID: ${{ vars.ALEX_UP_BOT_APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.ALEX_UP_BOT_PRIVATE_KEY }}

--- a/.github/workflows/scheduled-patch-release.yml
+++ b/.github/workflows/scheduled-patch-release.yml
@@ -10,7 +10,9 @@ jobs:
     permissions:
       contents: write
     if: ${{ github.repository == 'alextheman231/utility' }}
-    uses: alextheman231/github-actions/.github/workflows/scheduled-patch-release.yml@0776a9d83e56a216f52b56cb87ec0ff8f84a9368 # v12.3.0
+    uses: alextheman231/github-actions/.github/workflows/scheduled-patch-release.yml@beff06a63619c0122aeeca38b9cd48bf09f70cc9 # v12.4.0
+    with:
+      node-version: 26
     secrets:
       APP_ID: ${{ vars.ALEX_UP_BOT_APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.ALEX_UP_BOT_PRIVATE_KEY }}

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   update-dependencies:
     if: ${{ github.repository == 'alextheman231/utility' }}
-    uses: alextheman231/github-actions/.github/workflows/update-dependencies.yml@0776a9d83e56a216f52b56cb87ec0ff8f84a9368 # v12.3.0
+    uses: alextheman231/github-actions/.github/workflows/update-dependencies.yml@beff06a63619c0122aeeca38b9cd48bf09f70cc9 # v12.4.0
     secrets:
       APP_ID: ${{ vars.ALEX_UP_BOT_APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.ALEX_UP_BOT_PRIVATE_KEY }}
@@ -19,3 +19,4 @@ jobs:
       update_pnpm: true
       update_javascript_dependencies: true
       update_actions: true
+      node-version: 26


### PR DESCRIPTION
If CI passes with this enabled, we can then start migrating this project over to Node 26, and even potentially make use of Temporal as well.

# Tooling Change

This is a change to the tooling of `@alextheman/utility`. It changes the internal workings of the package and should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
