### PR TITLE
Add memoizeAsync

### DIFF
--- a/docs/releases/v5/v5.26/v5.26.0.md
+++ b/docs/releases/v5/v5.26/v5.26.0.md
@@ -1,0 +1,21 @@
+# v5.26.0 (Minor Release)
+
+<!-- alex-c-line-release-status-start -->
+**Status**: In progress
+<!-- alex-c-line-release-status-end -->
+
+<!-- alex-c-line-release-summary-start -->
+This is a new minor release of the `@alextheman/utility` package. It introduces new features and other backwards-compatible changes that should require little to no refactoring. Please read the description of changes below.
+<!-- alex-c-line-release-summary-end -->
+
+## Description of Changes
+
+<!-- user-editable-section-start -->
+- Add `memoizeAsync`
+  - This takes a function returning a Promise, and returns a new function that always points to the exact same Promise if invoked multiple times.
+  - Note that it ignores any arguments passed after the initial call, as it memoizes the first invocation of the function rather than memoizing results based on the arguments.
+
+## Additional Notes
+
+- This will be useful for the test fixture refactor in Lexicon, to ensure that fixtures in the new pattern only get created once, and only when we need them.
+<!-- user-editable-section-end -->

--- a/src/root/functions/miscellaneous/index.ts
+++ b/src/root/functions/miscellaneous/index.ts
@@ -3,6 +3,7 @@ export { default as createFormData } from "src/root/functions/miscellaneous/crea
 export { default as getRandomNumber } from "src/root/functions/miscellaneous/getRandomNumber";
 export { default as identity } from "src/root/functions/miscellaneous/identity";
 export { default as isOrdered } from "src/root/functions/miscellaneous/isOrdered";
+export { default as memoizeAsync } from "src/root/functions/miscellaneous/memoizeAsync";
 export { default as sayHello } from "src/root/functions/miscellaneous/sayHello";
 export { default as sortBy } from "src/root/functions/miscellaneous/sortBy";
 export { default as stringifyDotenv } from "src/root/functions/miscellaneous/stringifyDotenv";

--- a/src/root/functions/miscellaneous/memoizeAsync.ts
+++ b/src/root/functions/miscellaneous/memoizeAsync.ts
@@ -1,0 +1,28 @@
+type Callback<ArgsType extends ReadonlyArray<unknown>, ResolvedType> = (
+  ...args: ArgsType
+) => Promise<ResolvedType>;
+
+/**
+ * Memoizes the Promise returned by an asynchronous callback.
+ *
+ * Note that the callback is invoked at most once. Arguments supplied to subsequent calls are ignored because the Promise from the first invocation is always returned.
+ *
+ * @template ArgsType - The type of the function arguments.
+ * @template ResolvedType - The type of the Promise when resolved.
+ *
+ * @param callback - The function to memoize.
+ *
+ * @returns A callback with the Promise memoized. Multiple calls of this function should always point to the same Promise.
+ */
+function memoizeAsync<ArgsType extends ReadonlyArray<unknown>, ResolvedType>(
+  callback: Callback<ArgsType, ResolvedType>,
+): Callback<ArgsType, ResolvedType> {
+  let promise: Promise<ResolvedType> | undefined;
+
+  return (...args: ArgsType) => {
+    promise ??= callback(...args);
+    return promise;
+  };
+}
+
+export default memoizeAsync;

--- a/tests/functions/miscellaneous/memoizeAsync.test.ts
+++ b/tests/functions/miscellaneous/memoizeAsync.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "vitest";
+
+import { memoizeAsync } from "src/root";
+
+describe("memoizeAsync", () => {
+  test("Memoizes a Promise.", async () => {
+    const memoized = memoizeAsync(async () => {
+      return "hello";
+    });
+    const result = await memoized();
+
+    expect(result).toBe("hello");
+  });
+  test("If memoizing the same Promise, memoize the same instance.", async () => {
+    let count = 0;
+
+    const memoized = memoizeAsync(async () => {
+      count++;
+      return "hello";
+    });
+
+    const firstPromise = memoized();
+    const secondPromise = memoized();
+
+    expect(firstPromise).toBe(secondPromise);
+
+    const [firstResult, secondResult] = await Promise.all([firstPromise, secondPromise]);
+    expect(firstResult).toBe(secondResult);
+    expect(count).toBe(1);
+  });
+  test("Forwards the callback arguments", async () => {
+    const memoized = memoizeAsync(async (input) => {
+      return input;
+    });
+
+    const result = await memoized("hello");
+
+    expect(result).toBe("hello");
+  });
+  test("Ignores arguments after the first invocation.", async () => {
+    const memoized = memoizeAsync(async (input) => {
+      return input;
+    });
+
+    const firstResult = await memoized("first");
+    const secondResult = await memoized("second");
+
+    expect(firstResult).toBe("first");
+    expect(secondResult).toBe("first");
+  });
+});


### PR DESCRIPTION
This creates a new function that always points to the exact same promise if invoked multiple times. This will be useful for the test fixture refactor in Lexicon, to ensure that fixtures in the new pattern only get created once, and only when we need them.

# New Feature

This is a new feature for `@alextheman/utility`. It adds new functionality to the package.

Please see the commits tab of this pull request for the description of changes.
